### PR TITLE
Feature: systemd example files and create RPM artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ hs_err_pid*
 
 # Maven
 .mvn/*
+
+# Markdown previews.
+*.md.html

--- a/pom.xml
+++ b/pom.xml
@@ -10,16 +10,21 @@
 
 	<groupId>uk.ac.ebi.ega</groupId>
 	<artifactId>ega-fuse-client</artifactId>
-	<version>2.1.1-SNAPSHOT</version>
+	<version>2.1.0</version>
 	<packaging>jar</packaging>
 	<name>ega-fuse</name>
 	<description>ega fuse client</description>
+	<url>https://github.com/EGA-archive/ega-fuse-client</url>
+	<organization>
+		<name>The European Genome-phenome Archive (EGA)</name>
+		<url>https://ega-archive.org/</url>
+	</organization>
 
-    <scm>
-        <developerConnection>scm:git:git@github.com:EGA-archive/ega-fuse-client.git</developerConnection>
-        <tag>2.0.0</tag>
-    </scm>
-    
+	<scm>
+		<developerConnection>scm:git:git@github.com:EGA-archive/ega-fuse-client.git</developerConnection>
+		<tag>2.0.0</tag>
+	</scm>
+
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -28,13 +33,13 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 
-    <repositories>
+	<repositories>
 		<repository>
 			<id>jcenter</id>
 			<name>jcenter</name>
 			<url>https://jcenter.bintray.com</url>
 		</repository>
-    </repositories>
+	</repositories>
 
 	<dependencies>
 		<dependency>
@@ -73,8 +78,8 @@
 			<artifactId>spring-boot-starter-cache</artifactId>
 		</dependency>
 		<dependency>
-		    <groupId>com.github.ben-manes.caffeine</groupId>
-		    <artifactId>caffeine</artifactId>
+			<groupId>com.github.ben-manes.caffeine</groupId>
+			<artifactId>caffeine</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -86,10 +91,10 @@
 			<version>3.4.2</version>
 		</dependency>
 		<dependency>
-		    <groupId>com.github.stefanbirkner</groupId>
-		    <artifactId>system-rules</artifactId>
-		    <version>1.19.0</version>
-		    <scope>test</scope>
+			<groupId>com.github.stefanbirkner</groupId>
+			<artifactId>system-rules</artifactId>
+			<version>1.19.0</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.google.api-client</groupId>
@@ -110,7 +115,7 @@
 			<version>1.2.1</version>
 		</dependency>
 	</dependencies>
-	
+
 	<build>
 		<plugins>
 			<plugin>
@@ -126,12 +131,87 @@
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
 			<plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <configuration>
-                    <tagNameFormat>@{project.version}</tagNameFormat>
-                </configuration>
-            </plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-release-plugin</artifactId>
+				<configuration>
+					<tagNameFormat>@{project.version}</tagNameFormat>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>de.dentrassi.maven</groupId>
+				<artifactId>rpm</artifactId>
+				<version>1.6.0</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>rpm</goal>
+						</goals>
+						<configuration>
+							<attach>false</attach> 
+							<group>Application/Misc</group>
+							<skipSigning>true</skipSigning>
+							<prerequisites>
+								<dependency>
+									<name>java-11-openjdk</name>
+								</dependency>
+							</prerequisites>
+							<entries>
+								<entry>
+									<name>/usr/local/${project.artifactId}</name>
+									<directory>true</directory>
+									<user>root</user>
+									<group>root</group>
+									<mode>0755</mode>
+								</entry>
+								<entry>
+									<name>/usr/local/${project.artifactId}/${project.artifactId}-${project.version}.jar</name>
+									<file>target/${project.artifactId}-${project.version}.jar</file>
+									<user>root</user>
+									<group>root</group>
+									<mode>0644</mode>
+								</entry>
+								<entry>
+									<name>/usr/local/${project.artifactId}/${project.artifactId}.jar</name>
+									<linkTo>${project.artifactId}-${project.version}.jar</linkTo>
+									<user>root</user>
+									<group>root</group>
+								</entry>
+								<entry>
+									<name>/etc/${project.artifactId}.d/</name>
+									<directory>true</directory>
+									<user>root</user>
+									<group>root</group>
+									<mode>0750</mode>
+								</entry>
+								<entry>
+									<name>/etc/${project.artifactId}.d/${project.artifactId}.env.example</name>
+									<file>systemd/${project.artifactId}.env.example</file>
+									<user>root</user>
+									<group>root</group>
+									<mode>0640</mode>
+									<documentation>true</documentation>
+								</entry>
+								<entry>
+									<name>/etc/${project.artifactId}.d/${project.artifactId}.cf.example</name>
+									<file>systemd/${project.artifactId}.cf.example</file>
+									<user>root</user>
+									<group>root</group>
+									<mode>0640</mode>
+									<documentation>true</documentation>
+								</entry>
+								<entry>
+									<name>/usr/lib/systemd/system/${project.artifactId}@.service</name>
+									<file>systemd/${project.artifactId}@.service</file>
+									<user>root</user>
+									<group>root</group>
+									<mode>0644</mode>
+									<configuration>true</configuration>
+								</entry>
+							</entries>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/systemd/README.md
+++ b/systemd/README.md
@@ -1,0 +1,45 @@
+# Example files for running the EGA Fuse client as a service using systemd
+
+## ega-fuse-client@.service
+
+A systemd service file that allows running multiple instances of the EGA Fuse client for different mount points.
+This file must be located in
+```
+/usr/lib/systemd/system/ega-fuse-client@.service
+```
+Each instance requires:
+ * An instancename
+ * An empty dir to serve as mount point.
+ * Two configuration files (see below for details)
+   * located in ```/etc/ega-fuse-client.d/```
+   * and named ```instancename.cf``` and ```instancename.env```
+ * A symlink ```/etc/systemd/system/multi-user.target.wants/ega-fuse-client@instancename.service -> /usr/lib/systemd/system/ega-fuse-client@.service```
+   This symlink will be created with
+   ```
+   systemctl enable ega-fuse-client@instancename.service
+   ```
+
+When everything is in place, you can start an instance with:
+```
+systemctl start ega-fuse-client@instancename.service
+```
+
+## ega-fuse-client.cf.example
+
+Example of a **c**redential **f**ile. This contains the username and password that will be used to authenticate at the EGA.  
+This configuration file must be located at
+```
+/etc/ega-fuse-client.d/instancename.cf
+```
+
+## ega-fuse-client.env.example
+
+Example of an **env**ironment file. Here we define environment variables used by the systemd service file to start the EGA fuse client as a service.  
+
+ * ```EGA_FUSE_CLIENT_MOUNTPOINT```: the mount point to be used for the instance.
+ * ```EGA_FUSE_CLIENT_JAVA_HOME```: the path to the JAVA_HOME for the Java version to be used with the instance.
+
+This configuration file must be located at
+```
+/etc/ega-fuse-client.d/instancename.env
+```

--- a/systemd/ega-fuse-client.cf.example
+++ b/systemd/ega-fuse-client.cf.example
@@ -1,0 +1,2 @@
+username:_insert_user_name_here_
+password:_insert_password_here_

--- a/systemd/ega-fuse-client.env.example
+++ b/systemd/ega-fuse-client.env.example
@@ -1,0 +1,2 @@
+EGA_FUSE_CLIENT_MOUNTPOINT=/path/to/EGA/dataset
+EGA_FUSE_CLIENT_JAVA_HOME=/path/to/java_home

--- a/systemd/ega-fuse-client@.service
+++ b/systemd/ega-fuse-client@.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=EGA Fuse Client for %I mount.
+After=remote-fs.target
+Requires=remote-fs.target
+
+[Service]
+TimeoutStartSec=0
+EnvironmentFile=/etc/ega-fuse-client.d/%i.env
+SuccessExitStatus=143
+
+ExecStart=/usr/bin/env "${EGA_FUSE_CLIENT_JAVA_HOME}/bin/java" \
+-Xmx4g \
+-jar /usr/local/ega-fuse-client/ega-fuse-client.jar \
+-cf "/etc/ega-fuse-client.d/%i.cf" \
+-m "${EGA_FUSE_CLIENT_MOUNTPOINT}"
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
* Added example files for running EGA Fuse client as service with systemd
* Updated ```pom.xml``` to create RPM. This now uses a pure Java RPM creator (https://ctron.github.io/rpm-builder/index.html) to prevent the problems with the previous approach that had to be reverted (see https://github.com/EGA-archive/ega-fuse-client/pull/16)
* Exclude *.md.html Markdown -> HTML previews from repo. 